### PR TITLE
Added support for busy timeout API

### DIFF
--- a/android/sqlite3/src/main/java/com/totalpave/sqlite3/Sqlite.java
+++ b/android/sqlite3/src/main/java/com/totalpave/sqlite3/Sqlite.java
@@ -80,4 +80,5 @@ public class Sqlite {
     public static native int close(long db);
 
     public static native String getLibVersion();
+    public static native int setBusyTimeout(long db, int milliseconds);
 }

--- a/docs.md
+++ b/docs.md
@@ -136,3 +136,7 @@ Closes a database and frees resources. Using the database handle after closing w
 ##### String getLibVersion()
 
 Gets the SQLite lib version via sqlite3_libversion().
+
+##### int setBusyTimeout(long dbHandle, int milliseconds)
+
+Set busy timeout for the connection. See https://www.sqlite.org/c3ref/busy_timeout.html.

--- a/src/totalpave/jni.cc
+++ b/src/totalpave/jni.cc
@@ -317,6 +317,11 @@ extern "C" {
         const char* version = sqlite3_libversion();
         return env->NewStringUTF((const char*)version);
     }
+
+    JNIEXPORT jint JNICALL
+    Java_com_totalpave_sqlite3_Sqlite_setBusyTimeout(JNIEnv* env, jobject jptr, jlong db, jint milliseconds) {
+        return (jint)sqlite3_busy_timeout((sqlite3*)db, (int)milliseconds);
+    }
 }
 
 #endif


### PR DESCRIPTION
PRAGMA busy_timeout = :timeout was tried first.

For some reason it just didn't work. 

Alternative solution, adding support for the sqlite3_busy_timeout API.