### PR TITLE
(android) Print extended error

### DIFF
--- a/_buildAAR.sh
+++ b/_buildAAR.sh
@@ -41,7 +41,7 @@ gradle wrapper
 mkdir -p ../test/android/app/libs
 
 lBuildType=debug
-if [ `$buildType` == "Release" ]; then
+if [ "$buildType" == "Release" ]; then
     lBuildType="release"
 fi
 

--- a/_buildAAR.sh
+++ b/_buildAAR.sh
@@ -36,7 +36,7 @@ cp out/$buildType/android/x86_64/libsqlite3.so $ANDROID_JNI_LIBS/x86_64/libsqlit
 cd android
 
 gradle wrapper
-./gradlew build
+./gradlew assemble$buildType
 
 mkdir -p ../test/android/app/libs
 

--- a/build.sh
+++ b/build.sh
@@ -52,11 +52,6 @@ else
 fi
 
 mkdir -p build
-mkdir -p ./out/$buildType/android
-mkdir -p ./out/$buildType/android/arm64-v8a
-mkdir -p ./out/$buildType/android/armeabi-v7a
-mkdir -p ./out/$buildType/android/x86
-mkdir -p ./out/$buildType/android/x86_64
 
 for target in ${buildTargets[@]}; do
     

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,11 @@ else
 fi
 
 mkdir -p build
+mkdir -p ./out/$buildType/android
+mkdir -p ./out/$buildType/android/arm64-v8a
+mkdir -p ./out/$buildType/android/armeabi-v7a
+mkdir -p ./out/$buildType/android/x86
+mkdir -p ./out/$buildType/android/x86_64
 
 for target in ${buildTargets[@]}; do
     
@@ -78,3 +83,5 @@ source _buildAAR.sh
 if [ `uname` == "Darwin" ]; then
     source _buildXCFramework.sh
 fi
+
+echo "Finish $buildType task"

--- a/publish.sh
+++ b/publish.sh
@@ -20,6 +20,12 @@
 # OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 echo "Building release..."
+
+if [ `uname` != "Darwin" ]; then
+    echo "Mac is required for publishing"
+    exit 1
+fi
+
 ./clean.sh
 ./build.sh release
 

--- a/publish.sh
+++ b/publish.sh
@@ -20,6 +20,7 @@
 # OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 echo "Building release..."
+./clean.sh
 ./build.sh release
 
 echo "Publishing to bin..."

--- a/src/totalpave/include/tp/sqlite/utilities.h
+++ b/src/totalpave/include/tp/sqlite/utilities.h
@@ -28,7 +28,9 @@ namespace TP { namespace sqlite {
 
     constexpr char const * const TOTALPAVE_SQLITE_ERROR_DOMAIN = "com.totalpave.sqlite3.ErrorDomain";
     constexpr char const * const SQLITE_ERROR_DOMAIN = "com.sqlite3.ErrorDomain";
+    
     constexpr int const ERROR_CODE_BIND_PARAMETER_ERROR = 1;
+    constexpr int const ERROR_CODE_NO_DB                = 2;
 
     int lookupVariableIndex(sqlite3_stmt* state, const char* variable);
 }}


### PR DESCRIPTION
This PR includes 2 changes:

1) Changes to how errors gets generated to use extended error code generation.
2) Unrelated, however misc changes to build/release scripts

Regarding error codes:

Notable changes are:

unordered map to keep track of sqlite statement -> db pairs. On prepare (when statements are created), an entry is created, and the entry is erased on finalized (when the statement gets destroyed). This is so we can obtain a `sqlite3*` pointer for a given statement, which is required for the extended error API.

Added two new private JNI methods: `throwStatementError`, and `throwDBError`. `throwStatementError` is used by any JNI method that receives a statement, whereas `throwDBError` is used on any JNI method that receives a `sqlite3*` db. Both of these throw methods uses `throwJavaError` behind the scenes.

These new APIs makes use of `sqlite3_errmsg` which returns an SQLite error message that may use the extended error code if set, otherwise will fallback to the set primary result code. The `sqlite3_extended_errcode` also works in the same fashion.

Added `ERROR_CODE_NO_DB` for cases where there is no `sqlite3*` associated to a keyed `sqlite3_stmt*`, which may happen if you're using a finalized statement (which is an error in itself).

For the build script changes:

1. Added a mac check for publishing. Only macs should be able to publish because only macs can build iOS binaries (and android binaries).
2. Run clean before publish, mostly for sanity.
3. Changed AAR generation to use `assembleDebug` / `assembleRelease`, which will build only the respective AAR. This is so we don't have a "Debug" release AAR, and a "Release" debug AAR, so on. Release AAR will have release binaries, and debug AARs will have debug enabled binaries.

This is an android only change because only Android has a JNI API. iOS uses the sqlite API directly in the plugin and thus it will need to do this work manually itself.