### PR TITLE
feat(android): expose sqlite temp dir global var via JNI method

### DIFF
--- a/android/sqlite3/src/main/java/com/totalpave/sqlite3/Sqlite.java
+++ b/android/sqlite3/src/main/java/com/totalpave/sqlite3/Sqlite.java
@@ -40,6 +40,14 @@ public class Sqlite {
     public static final int NO_FOLLOW       = 0x01000000;
 
     /**
+     * Sets the usable tmp directory.
+     * This may be required if your queries can be large.
+     * It must be set **once** on initialization. It's unsafe
+     * to change this directory while any DBs are opened.
+     */
+    public static native void setTempDir(String path) throws SqliteException;
+
+    /**
      * @param path
      * @param openFlags
      * @return Pointer to Database handler

--- a/src/totalpave/include/tp/sqlite/utilities.h
+++ b/src/totalpave/include/tp/sqlite/utilities.h
@@ -31,6 +31,7 @@ namespace TP { namespace sqlite {
     
     constexpr int const ERROR_CODE_BIND_PARAMETER_ERROR = 1;
     constexpr int const ERROR_CODE_NO_DB                = 2;
+    constexpr int const ERROR_CODE_ALLOC_FAILURE        = 3;
 
     int lookupVariableIndex(sqlite3_stmt* state, const char* variable);
 }}


### PR DESCRIPTION
Creates a new JNI method `setTempDir` that to interface/sets the sqlite's global variable `sqlite3_temp_directory`

See https://www.sqlite.org/c3ref/temp_directory.html for more information on `sqlite3_temp_directory`

`setTempDir` properly handles the strings by copying the java string into memory allocated by `sqlite3_malloc`. This is required because sqlite3 will use this global variable and may free/change it, and it will assume the memory has been allocated with `sqlite3_malloc`. Therefore if it was allocated by another means, it may create undefined behaviour.

This is necessary because the standard OS tmp directory is not a writable directory on android. Each app has it's own cache directory that should be used as the temporary directory instead.

The sqlite plugin will utilise this JNI method to configure this on plugin startup.