### PR TITLE
Removed libcxx plugin dependency. This is already covered by the grad…

### DIFF
--- a/npm/plugin.template.xml
+++ b/npm/plugin.template.xml
@@ -8,7 +8,6 @@
   <repo>https://github.com/totalpaveinc/sqlite3</repo>
 
   <platform name="android">
-    <dependency id="@totalpave/cordova-plugin-libcxx" version="25.0.8775105" />
     <framework src="totalpave:sqlite3:SQLITE_VERSION" />
   </platform>
 


### PR DESCRIPTION
…le runtimeOnly dependency and caused duplicate libcxx symbols.