### PR TITLE
fix: Missing NSPrivacyCollectedDataTypes key

### DIFF
--- a/ios/sqlite3/PrivacyInfo.xcprivacy
+++ b/ios/sqlite3/PrivacyInfo.xcprivacy
@@ -4,5 +4,7 @@
 <dict>
 	<key>NSPrivacyTracking</key>
 	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array />
 </dict>
 </plist>


### PR DESCRIPTION
I guess we require to declare both base keys otherwise we get privacy errors like:

<img width="2588" alt="Screenshot 2024-05-29 at 10 24 04 AM" src="https://github.com/totalpaveinc/sqlite/assets/11200662/9159f0e6-04b8-4fbe-bb44-e9e8b8880651">

It doesn't seem to cause issues with previous upload tests but generating privacy report shows the error. Manually correcting it is shown to resolve it, but we should prepare a patch release with this change.